### PR TITLE
feat: 메인 페이지에서 보여질 글 목록에 대한 데이터를 불러오는 모듈 생성

### DIFF
--- a/src/api/Requests.js
+++ b/src/api/Requests.js
@@ -1,0 +1,42 @@
+import axios from "axios";
+
+async function articlesData() {
+  let articlesList;
+
+  const loadData = async function () {
+    try {
+      await axios.get("../../data/articlesList.json").then((res) => {
+        articlesList = res.data;
+      });
+    } catch (e) {
+      alert("Error at Requests.js : " + e);
+    }
+
+    await loadData();
+
+    const checkDataExist = async function () {
+      if (articlesList === undefined) {
+        await loadData();
+        return false;
+      }
+      return true;
+    };
+
+    const getArticlesList = function () {
+      if (!checkDataExist()) {
+        return;
+      }
+      return articlesList;
+    };
+
+    return { getArticlesList };
+  };
+}
+
+const data = await articlesData();
+
+export default function Requests() {
+  return {
+    getArticlesList: data.getArticlesList,
+  };
+}

--- a/src/api/Requests.js
+++ b/src/api/Requests.js
@@ -1,42 +1,36 @@
 import axios from "axios";
 
-async function articlesData() {
-  let articlesList;
+const attributeFilePath = {
+  main: "../../data/articlesList.json",
+  article: "../../data/article.json",
+};
 
-  const loadData = async function () {
-    try {
-      await axios.get("../../data/articlesList.json").then((res) => {
-        articlesList = res.data;
-      });
-    } catch (e) {
-      alert("Error at Requests.js : " + e);
-    }
-  };
-
-  await loadData();
-
-  const checkDataExist = async function () {
-    if (articlesList === undefined) {
-      await loadData();
-      return false;
-    }
-    return true;
-  };
-
-  const getArticlesList = function () {
-    if (!checkDataExist()) {
-      return;
-    }
-    return articlesList;
-  };
-
-  return { getArticlesList };
+async function fetchFile(path) {
+  try {
+    return await axios.get(path).then((res) => {
+      return res.data;
+    });
+  } catch (e) {
+    alert("Error at Requests.js : " + e);
+  }
 }
 
-const data = await articlesData();
+async function getData(attribute) {
+  const filePath = attributeFilePath[attribute];
+  return await fetchFile(filePath);
+}
+
+function getArticlesList() {
+  return getData("main");
+}
+
+function getArticle() {
+  return getData("article");
+}
 
 export default function Requests() {
   return {
-    getArticlesList: data.getArticlesList,
+    getArticlesList,
+    getArticle,
   };
 }

--- a/src/api/Requests.js
+++ b/src/api/Requests.js
@@ -11,26 +11,26 @@ async function articlesData() {
     } catch (e) {
       alert("Error at Requests.js : " + e);
     }
-
-    await loadData();
-
-    const checkDataExist = async function () {
-      if (articlesList === undefined) {
-        await loadData();
-        return false;
-      }
-      return true;
-    };
-
-    const getArticlesList = function () {
-      if (!checkDataExist()) {
-        return;
-      }
-      return articlesList;
-    };
-
-    return { getArticlesList };
   };
+
+  await loadData();
+
+  const checkDataExist = async function () {
+    if (articlesList === undefined) {
+      await loadData();
+      return false;
+    }
+    return true;
+  };
+
+  const getArticlesList = function () {
+    if (!checkDataExist()) {
+      return;
+    }
+    return articlesList;
+  };
+
+  return { getArticlesList };
 }
 
 const data = await articlesData();


### PR DESCRIPTION
## Description

- 해당 모듈은 data/articlesList.json 데이터를 불러와 반환합니다.

![image](https://github.com/f-lab-edu/clone-toss-tech/assets/48908205/a8be0f35-2f8e-402d-9960-8534ac4a08fe)
- 현재 단계는 위 그림에서 Service Worker와 MSW를 합친 수준에 속합니다.

- 해당 모듈은 추후 MSW가 적용될 예정이며, 적용 후 Mock server의 역할을 합니다.
- MSW가 적용되기 전까지는 데이터가 필요한 곳에서 직접 함수를 호출하여 데이터를 받습니다.

## What type of PR is this?

- [x] 🍕 Feature

## Related Tickets & Documents

[Ticket WOO-25](https://linear.app/woody-yoonkee/issue/WOO-25/%EB%A9%94%EC%9D%B8-%ED%8E%98%EC%9D%B4%EC%A7%80%EC%97%90%EC%84%9C-%EB%B3%B4%EC%97%AC%EC%A7%88-%EA%B8%80-%EB%AA%A9%EB%A1%9D%EC%97%90-%EB%8C%80%ED%95%9C-%EB%8D%B0%EC%9D%B4%ED%84%B0%EB%A5%BC-%EB%B6%88%EB%9F%AC%EC%98%A4%EB%8A%94-%EB%AA%A8%EB%93%88-%EC%83%9D%EC%84%B1)

[참고한 글 - (Kakao Tech)Mocking으로 생산성까지 챙기는 FE 개발](https://tech.kakao.com/2021/09/29/mocking-fe/)
