### PR TITLE
feat: 본문 페이지를 렌더하기 위한 views/article/index.js 생성

### DIFF
--- a/src/views/article/index.js
+++ b/src/views/article/index.js
@@ -1,0 +1,16 @@
+import { formatDate, html } from '../../utils';
+
+export default function render(props) {
+  const { body, created_date: createdDate, title, thumbnail_image: thumbnailImage } = props;
+  const $content = document.getElementById('content');
+  $content.innerHTML = html`
+    <article>
+      <header>
+        <img alt="제목 이미지" src="${thumbnailImage}" />
+        <h1>${title}</h1>
+        <span>${formatDate(createdDate)}</span>
+      </header>
+      <div>${body}</div>
+    </article>
+  `;
+}

--- a/src/views/article/index.js
+++ b/src/views/article/index.js
@@ -6,7 +6,9 @@ export default function render(props) {
   $content.innerHTML = html`
     <article>
       <header>
-        <img alt="제목 이미지" src="${thumbnailImage}" />
+        <div>
+          <img alt="제목 이미지" src="${thumbnailImage}" />
+        </div>
         <h1>${title}</h1>
         <span>${formatDate(createdDate)}</span>
       </header>


### PR DESCRIPTION
## Description

- 데이터를 받고, 해당 데이터로 본문 페이지를 렌더합니다.
- 이후 작성할 본문 페이지를 담당하는 controller에서 불러와 사용합니다.

## What type of PR is this?

- [x] 🍕 Feature

## Related Tickets & Documents

[Ticket: WOO-80](https://linear.app/woody-yoonkee/issue/WOO-80/본문-페이지-렌더를-위한-viewsarticleindexjs-생성)
